### PR TITLE
Remove call to _socket.close() that causes a stack overflow when connection is timed out.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ WSTransport.prototype.end = function() {
 	if (!this._socket)
 		throw new Error('Socket not connected');
 		
-	this._socket.close();	
+	this._socket = null;	
 };
 
 WSTransport.prototype.destroy = function() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,8 +52,11 @@ WSTransport.prototype.write = function (data) {
 WSTransport.prototype.end = function() {
 	if (!this._socket)
 		throw new Error('Socket not connected');
-		
-	this._socket = null;	
+	
+	if (this._socket.readyState !== this._socket.CLOSED) {	
+		this._socket.removeAllListeners();
+		this._socket.close();
+	}
 };
 
 WSTransport.prototype.destroy = function() {


### PR DESCRIPTION
Not too sure what the proper thing to do here is. 

Here's what happens:
- make a connection to a "bad" endpoint
- connection will timeout
- timeout is picked up in AMQP library and calls `end()` on the transport (in `connection._terminate()`)
- closing the socket causes the connection to call _terminate() again and we're in a loop.
