### PR TITLE
Do not try to call close on a socket that already failed. Emit 'end' …

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,9 +24,16 @@ WSTransport.prototype.connect = function (address, sslOptions) {
 
 	var self = this;
 	this._socket.on('connect', function () { self.emit('connect'); });
-	this._socket.on('error', function (err) { self.emit('error', err); });
+	this._socket.on('error', function (err) { 
+		self.hasError = true;
+		self.emit('error', err); 
+	});
 	this._socket.on('text', function (text) { self.emit('data', text); });
-	this._socket.on('close', function (code, reason) { self.emit('end', code + ": " + reason); });
+	this._socket.on('close', function (code, reason) { 
+		process.nextTick(function() { 
+			self.emit('end', code + ": " + reason);
+		});
+	});
 
 	this._socket.on('binary', function (inStream) {
 		// Empty buffer for collecting binary data
@@ -56,10 +63,11 @@ WSTransport.prototype.end = function() {
 	if (!this._socket)
 		throw new Error('Socket not connected');
 
-	if (this._socket.readyState !== this._socket.CLOSED) {
-		this._socket.removeAllListeners();
+	if (this._socket.readyState !== this._socket.CLOSED && !this.hasError) {
 		this._socket.close();
 	}
+
+	this._socket.removeAllListeners();
 };
 
 WSTransport.prototype.destroy = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqp10-transport-ws",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Provides a Websocket implementation for the transport layer for node-amqp10.",
   "main": "./lib",
   "scripts": {


### PR DESCRIPTION
…event on next tick.

The problem with the current implementation is that trying to call end() after an error (such as ECONNRESET) has happened provokes an exception because the socket is already closed. Suggested change: adding a Boolean to avoid calling close if an error has already occurred. 

The nextTick change is because with node-websocket, the 'close' event is emitted synchronously which differs from other transport implementations (tls and net). This discrepancy creates issues in node-amqp10.
